### PR TITLE
fix: VOL-4697 Digital sign in provider name is not getting displayed on snapshots

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -14,6 +14,9 @@ return [
         'delegators' => [
             'MvcTranslator' => [
                 \Dvsa\Olcs\Utils\Translation\TranslatorDelegatorFactory::class,
+            ],
+            \Laminas\Mvc\I18n\Translator::class => [
+                \Dvsa\Olcs\Utils\Translation\TranslatorDelegatorFactory::class,
             ]
         ],
         'shared' => [


### PR DESCRIPTION
## Description
There is a minor snapshot issue for all snapshots, where the provider name is not getting displayed when signed digitally

Related issue: [VOL-4697](https://dvsa.atlassian.net/browse/VOL-4697)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
