### PR TITLE
feat: drop Lamins 2 compatibility, last createService methods removed

### DIFF
--- a/src/Translation/NiTextTranslation.php
+++ b/src/Translation/NiTextTranslation.php
@@ -1,37 +1,20 @@
 <?php
 
-/**
- * Ni Text Translation
- *
- * @author Rob Caiger <rob@clocal.co.uk>
- */
-
 namespace Dvsa\Olcs\Utils\Translation;
 
 use Dvsa\Olcs\Utils\Helper\ValueHelper;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\I18n\Translator\Translator;
 use Interop\Container\ContainerInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
-/**
- * Ni Text Translation
- *
- * @author Rob Caiger <rob@clocal.co.uk>
- */
 class NiTextTranslation implements FactoryInterface
 {
     /**
      * @var Translator
      */
     private $translator;
-
-    public function createService(ServiceLocatorInterface $serviceLocator, $name = null, $requestedName = null): NiTextTranslation
-    {
-        return $this($serviceLocator, NiTextTranslation::class);
-    }
 
     public function setLocaleForNiFlag($niFlag)
     {

--- a/test/Translation/NiTextTranslationTest.php
+++ b/test/Translation/NiTextTranslationTest.php
@@ -40,7 +40,7 @@ class NiTextTranslationTest extends MockeryTestCase
         $sm->setService('translator', $this->translator);
 
         $this->sut = new NiTextTranslation();
-        $this->sut->createService($sm);
+        $this->sut->__invoke($sm, NiTextTranslation::class);
     }
 
     /**


### PR DESCRIPTION
Removes the last createService methods and bumps the FactoryInterface

Related issue: [VOL-3692](https://dvsa.atlassian.net/browse/VOL-3692)
